### PR TITLE
Add minimap2 submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,3 +22,6 @@
 [submodule "hapdip"]
 	path = hapdip
 	url = https://github.com/lh3/hapdip
+[submodule "minimap2"]
+	path = minimap2
+	url = https://github.com/lh3/minimap2

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-SUBDIRS=bfc bwa fermi2 htsbox ropebwt2 seqtk trimadap
+SUBDIRS=bfc bwa fermi2 htsbox minimap2 ropebwt2 seqtk trimadap
 
-all:fermi.kit/htsbox fermi.kit/ropebwt2 fermi.kit/bfc fermi.kit/bwa fermi.kit/seqtk fermi.kit/trimadap-mt \
+all:fermi.kit/htsbox fermi.kit/ropebwt2 fermi.kit/bfc fermi.kit/bwa fermi.kit/minimap2 fermi.kit/seqtk fermi.kit/trimadap-mt \
 	fermi.kit/fermi2 fermi.kit/fermi2.pl fermi.kit/fermi2.js fermi.kit/k8 fermi.kit/hapdip.js \
 	fermi.kit/run-calling
 
@@ -23,6 +23,9 @@ fermi.kit/bfc:prepare
 
 fermi.kit/bwa:prepare
 	cp bwa/bwa $@; strip $@
+
+fermi.kit/minimap2:prepare
+	cp minimap2/minimap2 $@; strip $@
 
 fermi.kit/fermi2:prepare
 	cp fermi2/fermi2 $@; strip $@


### PR DESCRIPTION
Without a minimap2 binary under `fermi.kit/` the `-m` option to `run-calling` was failing in a non-obvious way